### PR TITLE
[#47]Refect: 더보기 경로 개선

### DIFF
--- a/quizley/src/pages/RecordTodayInsightPage.tsx
+++ b/quizley/src/pages/RecordTodayInsightPage.tsx
@@ -129,7 +129,7 @@ export default function ReportTodayInsightPage() {
     });
   };
 
-  // 🔹 다른 유저의 생각 더보기 → 해당 커뮤니티 게시글(댓글)로 이동
+  // 다른 유저의 생각 더보기 → 오늘의 퀴즈 커뮤니티 상세로 이동
   const handleGoComments = () => {
     const quizId = record?.quizId;
     if (!quizId) {
@@ -137,7 +137,7 @@ export default function ReportTodayInsightPage() {
       return;
     }
 
-    navigate(`/community/user/${quizId}`, {
+    navigate(`/community/today/${quizId}`, {
       state: {
         from: "recordTodayInsight",
         focus: "comments",


### PR DESCRIPTION
Closes #47 

## ✨ Changes

- 기록 인사이트에 더보기 눌렀을 때 이동되는 화면 제목이 '오늘의 퀴즈'가 아니라 '익명이 게시' 게시글로 이동되어 이를 개선

## 💬 To. Reviewer

- 집중적으로 리뷰를 원하는 부분이 있다면 작성해 주세요.
